### PR TITLE
Also ignore PURE and ELEMENTAL after MODULE in Scanner and Emitter.

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,6 +7,9 @@
 
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
+  From Peter Diener:
+    - Additional fix to issue #3135 - Also handle 'pure' and 'elemental' type bound procedures
+
   From William Deegan:
 
     - Fix Issue #3283 - Handle using --config=force in combination with Decider('MD5-timestamp').
@@ -18,7 +21,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Decider and not clearing it when the configure context is completed.
     - Add default paths for yacc tool on windows to include cygwin, mingw, and chocolatey
 
-  From Github User pdiener:
+  From Peter Diener:
     - Fix issue #3135 - Handle Fortran submodules and type bound procedures
 
   From Daniel Moody:

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -9,6 +9,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Peter Diener:
     - Additional fix to issue #3135 - Also handle 'pure' and 'elemental' type bound procedures
+    - Fix issue #3135 - Handle Fortran submodules and type bound procedures
 
   From William Deegan:
 
@@ -21,10 +22,7 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Decider and not clearing it when the configure context is completed.
     - Add default paths for yacc tool on windows to include cygwin, mingw, and chocolatey
 
-  From Peter Diener:
-    - Fix issue #3135 - Handle Fortran submodules and type bound procedures
-
-  From Daniel Moody:
+From Daniel Moody:
     - Change the default for AppendENVPath to delete_existing=0, so path
       order will not be changed, unless explicitly set (Issue #3276)
     - Fixed bug which threw error when running SCons on windows system with no MSVC installed.

--- a/src/engine/SCons/Scanner/Fortran.py
+++ b/src/engine/SCons/Scanner/Fortran.py
@@ -287,6 +287,8 @@ def FortranScan(path_variable="FORTRANPATH"):
 #   MODULE PROCEDURE procedure_name
 #   MODULE SUBROUTINE subroutine_name
 #   MODULE FUNCTION function_name
+#   MODULE PURE SUBROUTINE|FUNCTION subroutine_name|function_name
+#   MODULE ELEMENTAL SUBROUTINE|FUNCTION subroutine_name|function_name
 #
 #   Here is a breakdown of the regex:
 #
@@ -296,15 +298,16 @@ def FortranScan(path_variable="FORTRANPATH"):
 #                                        insensitive
 #   \s+                                : match one or more white space
 #                                        characters
-#   (?!PROCEDURE|SUBROUTINE|FUNCTION)  : but *don't* match if the next word
-#                                        matches PROCEDURE, SUBROUTINE or
-#                                        FUNCTION (negative lookahead
-#                                        assertion), case insensitive
+#   (?!PROCEDURE|SUBROUTINE|FUNCTION|PURE|ELEMENTAL)
+#                                      : but *don't* match if the next word
+#                                        matches PROCEDURE, SUBROUTINE,
+#                                        FUNCTION, PURE or ELEMENTAL (negative
+#                                        lookahead assertion), case insensitive
 #   (\w+)                              : match one or more alphanumeric
 #                                        characters that make up the defined
 #                                        module name and save it in a group
 
-    def_regex = r"""(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION)(\w+)"""
+    def_regex = r"""(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION|PURE|ELEMENTAL)(\w+)"""
 
     scanner = F90Scanner("FortranScan",
                          "$FORTRANSUFFIXES",

--- a/src/engine/SCons/Tool/FortranCommon.py
+++ b/src/engine/SCons/Tool/FortranCommon.py
@@ -65,7 +65,7 @@ def _fortranEmitter(target, source, env):
        print("Could not locate " + str(node.name))
        return ([], [])
     # This has to match the def_regex in the Fortran scanner
-    mod_regex = r"""(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION)(\w+)"""
+    mod_regex = r"""(?i)^\s*MODULE\s+(?!PROCEDURE|SUBROUTINE|FUNCTION|PURE|ELEMENTAL)(\w+)"""
     cre = re.compile(mod_regex,re.M)
     # Retrieve all USE'd module names
     modules = cre.findall(node.get_text_contents())

--- a/test/fixture/fortran_unittests/test_1.f90
+++ b/test/fixture/fortran_unittests/test_1.f90
@@ -5,6 +5,8 @@ module test_1
     contains
       procedure :: set_n
       procedure :: get_n
+      procedure :: increment_n
+      procedure :: decrement_n
   end type test_type_1
 
 
@@ -19,6 +21,14 @@ interface
     class(test_type_1), intent(in) :: this
     integer :: get_n
   end function get_n
+
+  module pure subroutine increment_n ( this )
+    class(test_type_1), intent(inout) :: this
+  end subroutine increment_n
+
+  module elemental subroutine decrement_n ( this )
+    class(test_type_1), intent(inout) :: this
+  end subroutine decrement_n
 
 end interface
 
@@ -42,5 +52,17 @@ contains
 
     get_n = this%n
   end procedure get_n
+
+  module pure subroutine increment_n ( this )
+    class(test_type_1), intent(inout) :: this
+
+    this%n = this%n+1
+  end subroutine increment_n
+
+  module elemental subroutine decrement_n ( this )
+    class(test_type_1), intent(inout) :: this
+
+    this%n = this%n-1
+  end subroutine decrement_n
 
 end submodule test_1_impl

--- a/test/fixture/fortran_unittests/test_2.f90
+++ b/test/fixture/fortran_unittests/test_2.f90
@@ -5,6 +5,8 @@ module test_2
     contains
       procedure :: set_m
       procedure :: get_m
+      procedure :: increment_m
+      procedure :: decrement_m
   end type test_type_2
 
 
@@ -19,6 +21,14 @@ interface
     class(test_type_2), intent(in) :: this
     integer :: get_m
   end function get_m
+
+  module pure subroutine increment_m ( this )
+    class(test_type_2), intent(inout) :: this
+  end subroutine increment_m
+
+  module elemental subroutine decrement_m ( this )
+    class(test_type_2), intent(inout) :: this
+  end subroutine decrement_m
 
 end interface
 
@@ -42,5 +52,19 @@ contains
 
     get_m = this%m
   end procedure get_m
+
+  module procedure increment_m
+
+    implicit none
+
+    this%m = this%m+1
+  end procedure increment_m
+
+  module procedure decrement_m
+
+    implicit none
+
+    this%m = this%m-1
+  end procedure decrement_m
 
 end submodule test_2_impl

--- a/test/fixture/fortran_unittests/test_submodules.f90
+++ b/test/fixture/fortran_unittests/test_submodules.f90
@@ -12,4 +12,16 @@ program test_submodules
   print*,'var1%n = ', var1%get_n()
   print*,'var2%m = ', var2%get_m()
 
+  call var1%increment_n()
+  call var2%increment_m()
+
+  print*,'var1%n = ', var1%get_n()
+  print*,'var2%m = ', var2%get_m()
+
+  call var1%decrement_n()
+  call var2%decrement_m()
+
+  print*,'var1%n = ', var1%get_n()
+  print*,'var2%m = ', var2%get_m()
+
 end program test_submodules


### PR DESCRIPTION
Add subroutines that are declared pure and elemental to the test
of the Emitter. Note that in test_1.f90, the interface is repeated
in the submodule, whereas in test_2.f90 the interface is taken from
the module. Also note that the regex does not check whether
"module pure" or "module elemental" is actually followed by "subroutine" or
"function". This would be a syntax error and should trigger a compile time
error.

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

https://scons.org/guidelines.html


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [ ] I have updated the appropriate documentation
