### PR TITLE
Added specific test for Compilation Database to reproduce issue #4275…

### DIFF
--- a/test/CompilationDatabase/fixture/SConstruct_tempfile
+++ b/test/CompilationDatabase/fixture/SConstruct_tempfile
@@ -1,0 +1,45 @@
+import sys
+
+DefaultEnvironment(tools=[])
+env = Environment(
+    PYTHON=sys.executable,
+    LINK='$PYTHON mylink.py',
+    LINKFLAGS=[],
+    CC='$PYTHON mygcc.py cc',
+    CXX='$PYTHON mygcc.py c++',
+    tools=['gcc','g++','gnulink'],
+    MAXLINELENGTH=10,
+)
+# make sure TempFileMunge is used
+if 'TEMPFILE' not in env['CCCOM']:
+    env['CCCOM'] = '${TEMPFILE("%s")}'%(env['CCCOM'])
+
+env.Tool('compilation_db')
+
+outputs = []
+env_abs = env.Clone(COMPILATIONDB_USE_ABSPATH=True)
+outputs+= env_abs.CompilationDatabase('compile_commands_clone_abs.json')
+
+# Should be relative paths
+outputs+= env.CompilationDatabase('compile_commands_only_arg.json')
+outputs+= env.CompilationDatabase(target='compile_commands_target.json')
+
+# Should default name compile_commands.json
+outputs+= env.CompilationDatabase()
+
+# Should be absolute paths
+outputs+= env.CompilationDatabase('compile_commands_over_abs.json', COMPILATIONDB_USE_ABSPATH=True)
+outputs+= env.CompilationDatabase(target='compile_commands_target_over_abs.json', COMPILATIONDB_USE_ABSPATH=True)
+
+# Should be relative paths
+outputs+= env.CompilationDatabase('compile_commands_over_rel.json', COMPILATIONDB_USE_ABSPATH=False)
+
+# Try 1/0 for COMPILATIONDB_USE_ABSPATH
+outputs+= env.CompilationDatabase('compile_commands_over_abs_1.json', COMPILATIONDB_USE_ABSPATH=1)
+outputs+= env.CompilationDatabase('compile_commands_over_abs_0.json', COMPILATIONDB_USE_ABSPATH=0)
+
+env.Program('main', 'test_main.c')
+
+# Prevent actual call of $PYTHON @tempfile since "mygcc.py cc ..." is not a proper python statement
+# Interesting outputs are json databases
+env.Default(outputs)

--- a/test/CompilationDatabase/tmpfile.py
+++ b/test/CompilationDatabase/tmpfile.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# __COPYRIGHT__
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Test CompilationDatabase and several variations of ways to call it
+and values of COMPILATIONDB_USE_ABSPATH
+"""
+
+import sys
+import os
+import os.path
+import TestSCons
+
+test = TestSCons.TestSCons()
+
+test.file_fixture('mylink.py')
+test.file_fixture('mygcc.py')
+
+test.verbose_set(1)
+test.file_fixture('fixture/SConstruct_tempfile', 'SConstruct')
+test.file_fixture('test_main.c')
+test.run()
+
+rel_files = [
+    'compile_commands_only_arg.json',
+    'compile_commands_target.json',
+    'compile_commands.json',
+    'compile_commands_over_rel.json',
+    'compile_commands_over_abs_0.json'
+]
+
+abs_files = [
+    'compile_commands_clone_abs.json',
+    'compile_commands_over_abs.json',
+    'compile_commands_target_over_abs.json',
+    'compile_commands_over_abs_1.json',
+]
+
+example_rel_file = """[
+    {
+        "command": "%s mygcc.py cc -o test_main.o -c test_main.c",
+        "directory": "%s",
+        "file": "test_main.c",
+        "output": "test_main.o"
+    }
+]
+""" % (sys.executable, test.workdir)
+
+if sys.platform == 'win32':
+    example_rel_file = example_rel_file.replace('\\', '\\\\')
+
+for f in rel_files:
+    # print("Checking:%s" % f)
+    test.must_exist(f)
+    test.must_match(f, example_rel_file, mode='r')
+
+example_abs_file = """[
+    {
+        "command": "%s mygcc.py cc -o test_main.o -c test_main.c",
+        "directory": "%s",
+        "file": "%s",
+        "output": "%s"
+    }
+]
+""" % (sys.executable, test.workdir, os.path.join(test.workdir, 'test_main.c'), os.path.join(test.workdir, 'test_main.o'))
+
+if sys.platform == 'win32':
+    example_abs_file = example_abs_file.replace('\\', '\\\\')
+
+
+for f in abs_files:
+    test.must_exist(f)
+    test.must_match(f, example_abs_file, mode='r')
+
+
+test.pass_test()


### PR DESCRIPTION
Added specific test for Compilation Database to reproduce issue #4275 with TempFileMunge

This new test allows to reproduce issue #4275 in a platform independent way.
The only drawback is that I needed to disable actual build of output since I didn't find a way to execute command line from file using python.

## Contributor Checklist:

* [X] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
