### PR TITLE
Update PR 4305: failing stub qt tool

### DIFF
--- a/SCons/Tool/qt.py
+++ b/SCons/Tool/qt.py
@@ -25,11 +25,14 @@
 This is a fake tool to instruct any builds still referencing 'qt' instead
 of the new 'qt3' or a newer QT builder how to fix their now broken build.
 """
-import SCons.Warnings
+import SCons.Errors
 
 def generate(env):
-    pass
+    raise SCons.Errors.UserError(
+        "Deprecated tool 'qt' renamed to 'qt3'. "
+        "Please update your build accordingly. "
+        "'qt3' will be removed entirely in a future release."
+    )
 
 def exists(env):
     return False
-

--- a/SCons/Tool/qt3.xml
+++ b/SCons/Tool/qt3.xml
@@ -32,7 +32,9 @@ Sets &consvars; for building Qt3 applications.
 <note><para>
 This tool is only suitable for building targeted to Qt3,
 which is obsolete
-(<emphasis>the tool is deprecated since 4.3</emphasis>).
+(<emphasis>the tool is deprecated since 4.3,
+and was renamed to qt3 in 4.5.0.
+</emphasis>).
 There are contributed tools for Qt4 and Qt5, see
 <ulink url="https://github.com/SCons/scons-contrib">
 https://github.com/SCons/scons-contrib</ulink>.
@@ -195,6 +197,9 @@ If not already set,
 <varname>os.environ</varname>;
 if not found there, it tries to make a guess.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QTDIR.
+</para>
 </summary>
 </cvar>
 
@@ -204,6 +209,9 @@ if not found there, it tries to make a guess.
 Turn off scanning for mocable files. Use the &b-link-Moc; Builder to explicitly
 specify files to run <command>moc</command> on.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_AUTOSCAN.
+</para>
 </summary>
 </cvar>
 
@@ -212,6 +220,9 @@ specify files to run <command>moc</command> on.
 <para>
 The path where the Qt binaries are installed.
 The default value is '&cv-link-QT3DIR;<filename>/bin</filename>'.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_BINPATH.
 </para>
 </summary>
 </cvar>
@@ -225,6 +236,9 @@ Note: If you set this variable to <constant>None</constant>,
 the tool won't change the &cv-link-CPPPATH;
 construction variable.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_CPPPATH.
+</para>
 </summary>
 </cvar>
 
@@ -232,6 +246,9 @@ construction variable.
 <summary>
 <para>
 Prints lots of debugging information while scanning for moc files.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_DEBUG.
 </para>
 </summary>
 </cvar>
@@ -244,6 +261,9 @@ You may want to set this to <literal>'qt-mt'</literal>.
 Note: If you set this variable to <constant>None</constant>,
 the tool won't change the &cv-link-LIBS; variable.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_LIB.
+</para>
 </summary>
 </cvar>
 
@@ -255,6 +275,9 @@ The default value is '&cv-link-QT3DIR;<filename>/lib</filename>'.
 Note: If you set this variable to <constant>None</constant>,
 the tool won't change the &cv-link-LIBPATH;
 construction variable.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_LIBPATH.
 </para>
 </summary>
 </cvar>
@@ -282,6 +305,9 @@ Prefix for <command>moc</command> output files when source is a C++ file.
 Default value is <literal>'.moc'</literal>.
 Suffix for <command>moc</command> output files when source is a C++ file.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_MOCCXXSUFFIX.
+</para>
 </summary>
 </cvar>
 
@@ -291,6 +317,9 @@ Suffix for <command>moc</command> output files when source is a C++ file.
 Default value is <literal>'-i'</literal>.
 These flags are passed to <command>moc</command> when moccing a C++ file.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_MOCFROMCXXFLAGS.
+</para>
 </summary>
 </cvar>
 
@@ -298,6 +327,9 @@ These flags are passed to <command>moc</command> when moccing a C++ file.
 <summary>
 <para>
 Command to generate a moc file from a C++ file.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_MOCFROMCXXCOM.
 </para>
 </summary>
 </cvar>
@@ -308,6 +340,9 @@ Command to generate a moc file from a C++ file.
 The string displayed when generating a moc file from a C++ file.
 If this is not set, then &cv-link-QT3_MOCFROMCXXCOM; (the command line) is displayed.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_MOCFROMCXXCOMSTR.
+</para>
 </summary>
 </cvar>
 
@@ -315,6 +350,9 @@ If this is not set, then &cv-link-QT3_MOCFROMCXXCOM; (the command line) is displ
 <summary>
 <para>
 Command to generate a moc file from a header.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_MOCFROMSHCOM.
 </para>
 </summary>
 </cvar>
@@ -325,6 +363,9 @@ Command to generate a moc file from a header.
 The string displayed when generating a moc file from a C++ file.
 If this is not set, then &cv-link-QT3_MOCFROMHCOM; (the command line) is displayed.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_MOCFROMSHCOMSTR.
+</para>
 </summary>
 </cvar>
 
@@ -333,6 +374,9 @@ If this is not set, then &cv-link-QT3_MOCFROMHCOM; (the command line) is display
 <para>
 Default value is <literal>''</literal>. These flags are passed to <command>moc</command>
 when moccing a header file.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_MOCFROMSHFLAGS.
 </para>
 </summary>
 </cvar>
@@ -343,6 +387,9 @@ when moccing a header file.
 Default value is <literal>'moc_'</literal>.
 Prefix for <command>moc</command> output files when source is a header.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_MOCHPREFIX.
+</para>
 </summary>
 </cvar>
 
@@ -352,6 +399,9 @@ Prefix for <command>moc</command> output files when source is a header.
 Default value is '&cv-link-CXXFILESUFFIX;'.
 Suffix for moc output files when source is a header.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_MOCHSUFFIX.
+</para>
 </summary>
 </cvar>
 
@@ -360,6 +410,9 @@ Suffix for moc output files when source is a header.
 <para>
 Default value is '&cv-link-QT3_BINPATH;<filename>/uic</filename>'.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_UIC.
+</para>
 </summary>
 </cvar>
 
@@ -367,6 +420,9 @@ Default value is '&cv-link-QT3_BINPATH;<filename>/uic</filename>'.
 <summary>
 <para>
 Command to generate header files from <filename>.ui</filename> files.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_UICCOM.
 </para>
 </summary>
 </cvar>
@@ -377,6 +433,9 @@ Command to generate header files from <filename>.ui</filename> files.
 The string displayed when generating header files from <filename>.ui</filename> files.
 If this is not set, then &cv-link-QT3_UICCOM; (the command line) is displayed.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_UICCOMSTR.
+</para>
 </summary>
 </cvar>
 
@@ -385,6 +444,9 @@ If this is not set, then &cv-link-QT3_UICCOM; (the command line) is displayed.
 <para>
 Default value is ''. These flags are passed to <command>uic</command>
 when creating a header file from a <filename>.ui</filename> file.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_UICDECLFLAGS.
 </para>
 </summary>
 </cvar>
@@ -395,6 +457,9 @@ when creating a header file from a <filename>.ui</filename> file.
 Default value is <literal>''</literal>.
 Prefix for <command>uic</command> generated header files.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_UICDECLPREFIX.
+</para>
 </summary>
 </cvar>
 
@@ -403,6 +468,9 @@ Prefix for <command>uic</command> generated header files.
 <para>
 Default value is <literal>'.h'</literal>.
 Suffix for <command>uic</command> generated header files.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_UICDECLSUFFIX.
 </para>
 </summary>
 </cvar>
@@ -414,6 +482,9 @@ Default value is <literal>''</literal>.
 These flags are passed to <command>uic</command> when creating a C++
 file from a <filename>.ui</filename> file.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_UICIMPFLAGS.
+</para>
 </summary>
 </cvar>
 
@@ -422,6 +493,9 @@ file from a <filename>.ui</filename> file.
 <para>
 Default value is <literal>'uic_'</literal>.
 Prefix for uic generated implementation files.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_UICIMPLPREFIX.
 </para>
 </summary>
 </cvar>
@@ -432,6 +506,9 @@ Prefix for uic generated implementation files.
 Default value is '&cv-link-CXXFILESUFFIX;'. Suffix for uic generated implementation
 files.
 </para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_UICIMPLSUFFIX.
+</para>
 </summary>
 </cvar>
 
@@ -440,6 +517,9 @@ files.
 <para>
 Default value is <literal>'.ui'</literal>.
 Suffix of designer input files.
+</para>
+<para>
+<emphasis>Changed in 4.5.0</emphasis>: renamed from QT_UISUFFIX.
 </para>
 </summary>
 </cvar>

--- a/test/import.py
+++ b/test/import.py
@@ -128,23 +128,26 @@ if moc:
     import os.path
 
     qtdir = os.path.dirname(os.path.dirname(moc))
-
-    qt_err = r"""
-scons: warning: Could not detect qt3, using moc executable as a hint \(QT3DIR=%(qtdir)s\)
-""" % locals()
-
+    qt3_err = fr"""
+scons: warning: Could not detect qt3, using moc executable as a hint \(QT3DIR={qtdir}\)
+"""
 else:
-
-    qt_err = """
+    qt3_err = r"""
 scons: warning: Could not detect qt3, using empty QT3DIR
 """
 
-qt_warnings = [ re.compile(qt_err + TestSCons.file_expr) ]
+qt_moved = r"""
+scons: \*\*\* Deprecated tool 'qt' has moved to 'qt3'. Please update your build accordingly. 'qt3' will be removed entirely in a future release.
+"""
+
+qt3_warnings = [re.compile(qt3_err + TestSCons.file_expr)]
+qt_error = [re.compile(qt_moved + TestSCons.file_expr)]
 
 error_output = {
-    'icl' : intel_warnings,
-    'intelc' : intel_warnings,
-    'qt3' : qt_warnings,
+    'icl': intel_warnings,
+    'intelc': intel_warnings,
+    'qt3': qt3_warnings,
+    'qt': qt_error,
 }
 
 # An SConstruct for importing Tool names that have illegal characters
@@ -187,7 +190,7 @@ for tool in tools:
                 matched = 1
                 break
         if not matched:
-            print("Failed importing '%s', stderr:" % tool)
+            print(f"Failed importing '{tool}', stderr:")
             print(stderr)
             failures.append(tool)
 

--- a/test/import.py
+++ b/test/import.py
@@ -137,7 +137,7 @@ scons: warning: Could not detect qt3, using empty QT3DIR
 """
 
 qt_moved = r"""
-scons: \*\*\* Deprecated tool 'qt' has moved to 'qt3'. Please update your build accordingly. 'qt3' will be removed entirely in a future release.
+scons: \*\*\* Deprecated tool 'qt' renamed to 'qt3'. Please update your build accordingly. 'qt3' will be removed entirely in a future release.
 """
 
 qt3_warnings = [re.compile(qt3_err + TestSCons.file_expr)]
@@ -181,9 +181,9 @@ for tool in tools:
         test.write('SConstruct', indirect_import % locals())
     else:
         test.write('SConstruct', direct_import % locals())
-    test.run(stderr=None)
+    test.run(stderr=None, status=None)
     stderr = test.stderr()
-    if stderr:
+    if stderr or test.status:
         matched = None
         for expression in error_output.get(tool, []):
             if expression.match(stderr):


### PR DESCRIPTION
Proposed addition of code to cause stub qt to fail, and test/import.py to detect this situation. Unfortunately, it still seems to mismatch on the string in the test.. needs adjustment.

Doc updates to record rename version.

## Remove this paragraph
Please have a look at our developer documentation before submitting your Pull Request.

https://scons.org/guidelines.html


## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
