### PR TITLE
Add manpage entry for --cache-dir + tweaks

### DIFF
--- a/SCons/Script/SConsOptions.py
+++ b/SCons/Script/SConsOptions.py
@@ -798,7 +798,7 @@ def Parser(version):
                   dest='cache_dir',
                   metavar='CACHEDIR',
                   help='Enable the derived‑file cache and set its directory to CACHEDIR',
-                  default=None)
+                  default="")
 
     op.add_option('--cache-disable', '--no-cache',
                   dest='cache_disable', default=False,

--- a/doc/man/scons.xml
+++ b/doc/man/scons.xml
@@ -708,6 +708,20 @@ derived-file cache specified by &f-link-CacheDir;.</para>
   </listitem>
   </varlistentry>
 
+  <varlistentry id="opt-cache-dir">
+  <term>-<option>-cache-dir=<replaceable>cachedir</replaceable></option></term>
+  <listitem>
+<para>Enable derived-file caching globally, using
+<replaceable>cachedir</replaceable> as the cache directory.
+An individual &consenv; may still specify a different
+cache directory by calling &f-link-env-CacheDir;.
+</para>
+<para><emphasis>Added in version NEXT_RELEASE.</emphasis></para>
+  </listitem>
+  </varlistentry>
+
+  <varlistentry>
+
   <varlistentry id="opt-cache-disable">
   <term>
     <option>--cache-disable</option>,
@@ -9073,7 +9087,7 @@ However, the following variables are imported by
 </para>
 
 <variablelist>
-  <varlistentry>
+  <varlistentry id="v-SCONS_LIB_DIR">
     <term><envar>SCONS_LIB_DIR</envar></term>
     <listitem>
 <para>Specifies the directory that contains the &scons;
@@ -9099,7 +9113,7 @@ so the command line can be used to override
     </listitem>
   </varlistentry>
 
-  <varlistentry>
+  <varlistentry id="v-SCONS_CACHE_MSVC_CONFIG">
     <term><envar>SCONS_CACHE_MSVC_CONFIG</envar></term>
     <listitem>
 <para>(Windows only). If set, save the shell environment variables

--- a/doc/user/caching.xml
+++ b/doc/user/caching.xml
@@ -73,12 +73,21 @@ CacheDir('/usr/local/build_cache')
     </scons_example>
 
     <para>
+    A cache directory can also be specified on the command line
+    (<literal>--cache-dir=CACHEDIR</literal>) - useful for the case
+    where you have a permanent &f-link-CacheDir; call
+    but want to override it temporarily for a given build.
+    You can also create a cache directory specific to a &consenv;
+    by using the <literal>env.CacheDir()</literal> form.
+    </para>
+
+    <para>
 
     The cache directory you specify must
     have read and write access for all developers
-    who will be accessing the cached files
-    (if <option>--cache-readonly</option> is used,
-    only read access is required).
+    who will be accessing the cached files.
+    If <option>--cache-readonly</option> is used,
+    only read access is required.
     It should also be in some central location
     that all builds will be able to access.
     In environments where developers are using separate systems
@@ -86,9 +95,11 @@ CacheDir('/usr/local/build_cache')
     this directory would typically be
     on a shared or NFS-mounted file system.
     While &SCons; will create the specified cache directory as needed,
-    in this multiuser scenario it is usually best
-    to create it ahead of time, so the access rights
-    can be set up correctly.
+    the underlying &Python; library function used for this will
+    create it accessbile only for the creating user ID,
+    so for a shared cache, it is usually best
+    to create it ahead of time, and manually set up
+    the access rights as needed.
 
     </para>
 


### PR DESCRIPTION
Tweak: intermediate directories are now made so the temporary cachedir creation is less likely to fail.

Tweak: if debug output is selected and sent to a file, the file is now opened in append mode. This fixes a problem of lost output if multiple cachedirs are used in one run (presumably rare except for testing scenarios), but isn't an ideal solution for the issue.


